### PR TITLE
Add Express backend and API integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,11 @@ GOOGLE_CLIENT_SECRET=
 # Database
 # -----------------------------------------------------------------------------
 DATABASE_URL=
+# Backend database connection
+BACKEND_DATABASE_URL=postgresql://postgres:postgres@db:5432/appdb
+# JWT secret for backend
+JWT_SECRET=change-this-secret
+PORT=12000
 
 # -----------------------------------------------------------------------------
 # API

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --production || true
+COPY . .
+RUN npx prisma generate --schema backend/prisma/schema.prisma || true
+CMD ["node", "backend/src/index.js"]
+EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+This is a full-stack application built with Next.js for the frontend and an Express + Prisma backend.
 
 ## Getting Started
 
-First, run the development server:
+### Development
+
+Install dependencies and start the Next.js dev server:
 
 ```bash
 npm run dev
@@ -11,6 +13,14 @@ yarn dev
 # or
 pnpm dev
 ```
+
+For the backend and database you can use Docker:
+
+```bash
+docker-compose up --build
+```
+
+This will start a Postgres database and the Express API on port `12000`.
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
@@ -27,8 +37,16 @@ To learn more about Next.js, take a look at the following resources:
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
 
-## Deploy on Vercel
+## Deployment
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+The frontend can be deployed to Vercel while the backend can run on any platform that supports Docker (Render, Railway, Heroku, etc.).
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+1. Build the frontend and backend images:
+
+```bash
+docker-compose build
+```
+
+2. Push the images to your container registry and deploy the services.
+
+Ensure the environment variables in `.env` match your production configuration.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --production || true
+COPY . .
+RUN npx prisma generate
+EXPOSE 12000
+CMD ["node", "src/index.js"]

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node src/index.js",
+    "dev": "nodemon src/index.js",
+    "migrate": "prisma migrate dev",
+    "generate": "prisma generate"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.22.0",
+    "bcryptjs": "^2.4.3",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "express-async-handler": "^1.2.0",
+    "helmet": "^7.0.0",
+    "jsonwebtoken": "^9.0.1",
+    "morgan": "^1.10.0"
+  },
+  "devDependencies": {
+    "prisma": "^5.22.0",
+    "nodemon": "^3.0.2"
+  }
+}

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,0 +1,62 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("BACKEND_DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id       Int     @id @default(autoincrement())
+  name     String
+  email    String  @unique
+  password String
+  role     String  @default("user")
+  orders   Order[]
+  invoices Invoice[]
+}
+
+model Product {
+  id          Int     @id @default(autoincrement())
+  name        String
+  description String?
+  price       Float
+  orders      Order[]
+}
+
+model Order {
+  id        Int      @id @default(autoincrement())
+  user      User     @relation(fields: [userId], references: [id])
+  userId    Int
+  product   Product  @relation(fields: [productId], references: [id])
+  productId Int
+  quantity  Int
+  status    String   @default("pending")
+  createdAt DateTime @default(now())
+}
+
+model Course {
+  id          Int     @id @default(autoincrement())
+  title       String
+  description String?
+  lessons     Lesson[]
+}
+
+model Lesson {
+  id       Int    @id @default(autoincrement())
+  course   Course @relation(fields: [courseId], references: [id])
+  courseId Int
+  title    String
+  content  String?
+}
+
+model Invoice {
+  id        Int      @id @default(autoincrement())
+  user      User     @relation(fields: [userId], references: [id])
+  userId    Int
+  amount    Float
+  status    String   @default("pending")
+  dueDate   DateTime
+  createdAt DateTime @default(now())
+}

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,0 +1,42 @@
+const express = require('express');
+const cors = require('cors');
+const morgan = require('morgan');
+const helmet = require('helmet');
+const dotenv = require('dotenv');
+const { PrismaClient } = require('@prisma/client');
+const authRoutes = require('./routes/auth');
+const userRoutes = require('./routes/users');
+const productRoutes = require('./routes/products');
+const orderRoutes = require('./routes/orders');
+const courseRoutes = require('./routes/courses');
+const invoiceRoutes = require('./routes/invoices');
+const { errorHandler } = require('./middleware/errorHandler');
+
+dotenv.config();
+
+const app = express();
+const prisma = new PrismaClient();
+
+app.use(morgan('dev'));
+app.use(helmet());
+app.use(cors());
+app.use(express.json());
+
+app.use((req, res, next) => {
+  req.prisma = prisma;
+  next();
+});
+
+app.use('/api/auth', authRoutes);
+app.use('/api/users', userRoutes);
+app.use('/api/products', productRoutes);
+app.use('/api/orders', orderRoutes);
+app.use('/api/courses', courseRoutes);
+app.use('/api/invoices', invoiceRoutes);
+
+app.use(errorHandler);
+
+const PORT = process.env.PORT || 12000;
+app.listen(PORT, () => {
+  console.log(`Backend listening on port ${PORT}`);
+});

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,0 +1,18 @@
+const jwt = require('jsonwebtoken');
+
+function auth(req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+  const token = authHeader.split(' ')[1];
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = payload;
+    next();
+  } catch (err) {
+    res.status(401).json({ message: 'Invalid token' });
+  }
+}
+
+module.exports = auth;

--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -1,0 +1,6 @@
+function errorHandler(err, req, res, next) {
+  console.error(err);
+  res.status(err.status || 500).json({ message: err.message || 'Server error' });
+}
+
+module.exports = { errorHandler };

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,0 +1,48 @@
+const express = require('express');
+const asyncHandler = require('express-async-handler');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+
+const router = express.Router();
+
+// Register
+router.post('/register', asyncHandler(async (req, res) => {
+  const { name, email, password } = req.body;
+  if (!name || !email || !password) {
+    return res.status(400).json({ message: 'All fields are required' });
+  }
+  const existing = await req.prisma.user.findUnique({ where: { email } });
+  if (existing) {
+    return res.status(400).json({ message: 'Email already in use' });
+  }
+  const hashed = await bcrypt.hash(password, 10);
+  const user = await req.prisma.user.create({ data: { name, email, password: hashed } });
+  const token = jwt.sign({ id: user.id, email: user.email }, process.env.JWT_SECRET);
+  res.json({ token, id: user.id, name: user.name, email: user.email });
+}));
+
+// Login
+router.post('/login', asyncHandler(async (req, res) => {
+  const { email, password } = req.body;
+  const user = await req.prisma.user.findUnique({ where: { email } });
+  if (!user) return res.status(400).json({ message: 'Invalid credentials' });
+  const match = await bcrypt.compare(password, user.password);
+  if (!match) return res.status(400).json({ message: 'Invalid credentials' });
+  const token = jwt.sign({ id: user.id, email: user.email }, process.env.JWT_SECRET);
+  res.json({ token, id: user.id, name: user.name, email: user.email });
+}));
+
+router.get('/me', asyncHandler(async (req, res) => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader) return res.status(401).json({ message: 'Unauthorized' });
+  const token = authHeader.split(' ')[1];
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET);
+    const user = await req.prisma.user.findUnique({ where: { id: payload.id } });
+    res.json({ id: user.id, name: user.name, email: user.email });
+  } catch (err) {
+    res.status(401).json({ message: 'Invalid token' });
+  }
+}));
+
+module.exports = router;

--- a/backend/src/routes/courses.js
+++ b/backend/src/routes/courses.js
@@ -1,0 +1,55 @@
+const express = require('express');
+const asyncHandler = require('express-async-handler');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+
+router.use(auth);
+
+router.get('/', asyncHandler(async (req, res) => {
+  const courses = await req.prisma.course.findMany({ include: { lessons: true } });
+  res.json(courses);
+}));
+
+router.get('/:id', asyncHandler(async (req, res) => {
+  const course = await req.prisma.course.findUnique({ where: { id: parseInt(req.params.id) }, include: { lessons: true } });
+  if (!course) return res.status(404).json({ message: 'Not found' });
+  res.json(course);
+}));
+
+router.post('/', asyncHandler(async (req, res) => {
+  const { title, description } = req.body;
+  const course = await req.prisma.course.create({ data: { title, description } });
+  res.status(201).json(course);
+}));
+
+router.put('/:id', asyncHandler(async (req, res) => {
+  const { title, description } = req.body;
+  const course = await req.prisma.course.update({ where: { id: parseInt(req.params.id) }, data: { title, description } });
+  res.json(course);
+}));
+
+router.delete('/:id', asyncHandler(async (req, res) => {
+  await req.prisma.course.delete({ where: { id: parseInt(req.params.id) } });
+  res.status(204).end();
+}));
+
+// lessons
+router.post('/:id/lessons', asyncHandler(async (req, res) => {
+  const { title, content } = req.body;
+  const lesson = await req.prisma.lesson.create({ data: { title, content, courseId: parseInt(req.params.id) } });
+  res.status(201).json(lesson);
+}));
+
+router.put('/:id/lessons/:lessonId', asyncHandler(async (req, res) => {
+  const { title, content } = req.body;
+  const lesson = await req.prisma.lesson.update({ where: { id: parseInt(req.params.lessonId) }, data: { title, content } });
+  res.json(lesson);
+}));
+
+router.delete('/:id/lessons/:lessonId', asyncHandler(async (req, res) => {
+  await req.prisma.lesson.delete({ where: { id: parseInt(req.params.lessonId) } });
+  res.status(204).end();
+}));
+
+module.exports = router;

--- a/backend/src/routes/invoices.js
+++ b/backend/src/routes/invoices.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const asyncHandler = require('express-async-handler');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+
+router.use(auth);
+
+router.get('/', asyncHandler(async (req, res) => {
+  const invoices = await req.prisma.invoice.findMany({ include: { user: true } });
+  res.json(invoices);
+}));
+
+router.get('/:id', asyncHandler(async (req, res) => {
+  const invoice = await req.prisma.invoice.findUnique({ where: { id: parseInt(req.params.id) }, include: { user: true } });
+  if (!invoice) return res.status(404).json({ message: 'Not found' });
+  res.json(invoice);
+}));
+
+router.post('/', asyncHandler(async (req, res) => {
+  const { userId, amount, status, dueDate } = req.body;
+  const invoice = await req.prisma.invoice.create({ data: { userId, amount, status, dueDate: new Date(dueDate) } });
+  res.status(201).json(invoice);
+}));
+
+router.put('/:id/status', asyncHandler(async (req, res) => {
+  const { status } = req.body;
+  const invoice = await req.prisma.invoice.update({ where: { id: parseInt(req.params.id) }, data: { status } });
+  res.json(invoice);
+}));
+
+router.delete('/:id', asyncHandler(async (req, res) => {
+  await req.prisma.invoice.delete({ where: { id: parseInt(req.params.id) } });
+  res.status(204).end();
+}));
+
+module.exports = router;

--- a/backend/src/routes/orders.js
+++ b/backend/src/routes/orders.js
@@ -1,0 +1,32 @@
+const express = require('express');
+const asyncHandler = require('express-async-handler');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+
+router.use(auth);
+
+router.get('/', asyncHandler(async (req, res) => {
+  const orders = await req.prisma.order.findMany({ include: { product: true, user: true } });
+  res.json(orders);
+}));
+
+router.get('/:id', asyncHandler(async (req, res) => {
+  const order = await req.prisma.order.findUnique({ where: { id: parseInt(req.params.id) }, include: { product: true, user: true } });
+  if (!order) return res.status(404).json({ message: 'Not found' });
+  res.json(order);
+}));
+
+router.post('/', asyncHandler(async (req, res) => {
+  const { userId, productId, quantity, status } = req.body;
+  const order = await req.prisma.order.create({ data: { userId, productId, quantity, status } });
+  res.status(201).json(order);
+}));
+
+router.put('/:id', asyncHandler(async (req, res) => {
+  const { status, quantity } = req.body;
+  const order = await req.prisma.order.update({ where: { id: parseInt(req.params.id) }, data: { status, quantity } });
+  res.json(order);
+}));
+
+module.exports = router;

--- a/backend/src/routes/products.js
+++ b/backend/src/routes/products.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const asyncHandler = require('express-async-handler');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+
+router.use(auth);
+
+router.get('/', asyncHandler(async (req, res) => {
+  const products = await req.prisma.product.findMany();
+  res.json(products);
+}));
+
+router.get('/:id', asyncHandler(async (req, res) => {
+  const product = await req.prisma.product.findUnique({ where: { id: parseInt(req.params.id) } });
+  if (!product) return res.status(404).json({ message: 'Not found' });
+  res.json(product);
+}));
+
+router.post('/', asyncHandler(async (req, res) => {
+  const { name, description, price } = req.body;
+  const product = await req.prisma.product.create({ data: { name, description, price } });
+  res.status(201).json(product);
+}));
+
+router.put('/:id', asyncHandler(async (req, res) => {
+  const { name, description, price } = req.body;
+  const product = await req.prisma.product.update({ where: { id: parseInt(req.params.id) }, data: { name, description, price } });
+  res.json(product);
+}));
+
+router.delete('/:id', asyncHandler(async (req, res) => {
+  await req.prisma.product.delete({ where: { id: parseInt(req.params.id) } });
+  res.status(204).end();
+}));
+
+module.exports = router;

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -1,0 +1,38 @@
+const express = require('express');
+const asyncHandler = require('express-async-handler');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+
+router.use(auth);
+
+router.get('/', asyncHandler(async (req, res) => {
+  const users = await req.prisma.user.findMany({ select: { id: true, name: true, email: true, role: true } });
+  res.json(users);
+}));
+
+router.get('/:id', asyncHandler(async (req, res) => {
+  const user = await req.prisma.user.findUnique({ where: { id: parseInt(req.params.id) }, select: { id: true, name: true, email: true, role: true } });
+  if (!user) return res.status(404).json({ message: 'Not found' });
+  res.json(user);
+}));
+
+router.post('/', asyncHandler(async (req, res) => {
+  const { name, email, password, role } = req.body;
+  const hashed = await require('bcryptjs').hash(password, 10);
+  const user = await req.prisma.user.create({ data: { name, email, password: hashed, role } });
+  res.status(201).json({ id: user.id, name: user.name, email: user.email, role: user.role });
+}));
+
+router.put('/:id', asyncHandler(async (req, res) => {
+  const { name, email, role } = req.body;
+  const user = await req.prisma.user.update({ where: { id: parseInt(req.params.id) }, data: { name, email, role } });
+  res.json({ id: user.id, name: user.name, email: user.email, role: user.role });
+}));
+
+router.delete('/:id', asyncHandler(async (req, res) => {
+  await req.prisma.user.delete({ where: { id: parseInt(req.params.id) } });
+  res.status(204).end();
+}));
+
+module.exports = router;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15-alpine
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: appdb
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  backend:
+    build: ./backend
+    environment:
+      - PORT=12000
+      - BACKEND_DATABASE_URL=postgresql://postgres:postgres@db:5432/appdb
+      - JWT_SECRET=change-this-secret
+    depends_on:
+      - db
+    ports:
+      - "12000:12000"
+    volumes:
+      - ./backend:/app
+
+volumes:
+  db-data:

--- a/src/app/[lang]/(dashboard)/(private)/apps/ecommerce/products/list/page.tsx
+++ b/src/app/[lang]/(dashboard)/(private)/apps/ecommerce/products/list/page.tsx
@@ -1,34 +1,28 @@
-// MUI Imports
-import Grid from '@mui/material/Grid2'
+'use client'
 
-// Component Imports
+import Grid from '@mui/material/Grid2'
+import { useEffect, useState } from 'react'
 import ProductListTable from '@views/apps/ecommerce/products/list/ProductListTable'
 import ProductCard from '@views/apps/ecommerce/products/list/ProductCard'
+import { productAPI } from '@/api'
 
-// Data Imports
-import { getEcommerceData } from '@/app/server/actions'
+interface Product {
+  id: number
+  name: string
+  description?: string
+  price: number
+}
 
-/**
- * ! If you need data using an API call, uncomment the below API code, update the `process.env.API_URL` variable in the
- * ! `.env` file found at root of your project and also update the API endpoints like `/apps/ecommerce` in below example.
- * ! Also, remove the above server action import and the action itself from the `src/app/server/actions.ts` file to clean up unused code
- * ! because we've used the server action for getting our static data.
- */
+const eCommerceProductsList = () => {
+  const [products, setProducts] = useState<Product[] | null>(null)
+  const [error, setError] = useState('')
 
-/* const getEcommerceData = async () => {
-  // Vars
-  const res = await fetch(`${process.env.API_URL}/apps/ecommerce`)
-
-  if (!res.ok) {
-    throw new Error('Failed to fetch ecommerce data')
-  }
-
-  return res.json()
-} */
-
-const eCommerceProductsList = async () => {
-  // Vars
-  const data = await getEcommerceData()
+  useEffect(() => {
+    productAPI
+      .getProducts()
+      .then(res => setProducts(res.data))
+      .catch(() => setError('Failed to load products'))
+  }, [])
 
   return (
     <Grid container spacing={6}>
@@ -36,7 +30,9 @@ const eCommerceProductsList = async () => {
         <ProductCard />
       </Grid>
       <Grid size={{ xs: 12 }}>
-        <ProductListTable productData={data?.products} />
+        {error && <p>{error}</p>}
+        {!products && !error && <p>Loading...</p>}
+        {products && <ProductListTable productData={products} />}
       </Grid>
     </Grid>
   )

--- a/src/app/server/actions.ts
+++ b/src/app/server/actions.ts
@@ -1,24 +1,27 @@
 /**
- * ! The server actions below are used to fetch the static data from the fake-db. If you're using an ORM
- * ! (Object-Relational Mapping) or a database, you can swap the code below with your own database queries.
+ * Server actions used to retrieve data for the dashboard. Some helpers now
+ * fetch data from the API defined in `API_URL` while others still use the
+ * static fake database.
  */
 
 'use server'
 
 // Data Imports
-import { db as eCommerceData } from '@/fake-db/apps/ecommerce'
 import { db as academyData } from '@/fake-db/apps/academy'
 import { db as vehicleData } from '@/fake-db/apps/logistics'
-import { db as invoiceData } from '@/fake-db/apps/invoice'
-import { db as userData } from '@/fake-db/apps/userList'
 import { db as permissionData } from '@/fake-db/apps/permissions'
 import { db as profileData } from '@/fake-db/pages/userProfile'
 import { db as faqData } from '@/fake-db/pages/faq'
 import { db as pricingData } from '@/fake-db/pages/pricing'
 import { db as statisticsData } from '@/fake-db/pages/widgetExamples'
 
+const API_URL = process.env.API_URL || 'http://localhost:12000/api'
+
 export const getEcommerceData = async () => {
-  return eCommerceData
+  const res = await fetch(`${API_URL}/products`, { cache: 'no-store' })
+  if (!res.ok) throw new Error('Failed to fetch products')
+  const products = await res.json()
+  return { products }
 }
 
 export const getAcademyData = async () => {
@@ -30,11 +33,15 @@ export const getLogisticsData = async () => {
 }
 
 export const getInvoiceData = async () => {
-  return invoiceData
+  const res = await fetch(`${API_URL}/invoices`, { cache: 'no-store' })
+  if (!res.ok) throw new Error('Failed to fetch invoices')
+  return await res.json()
 }
 
 export const getUserData = async () => {
-  return userData
+  const res = await fetch(`${API_URL}/users`, { cache: 'no-store' })
+  if (!res.ok) throw new Error('Failed to fetch users')
+  return await res.json()
 }
 
 export const getPermissionsData = async () => {


### PR DESCRIPTION
## Summary
- set up Express backend with Prisma models
- provide CRUD routes for products, users, orders, courses and invoices
- add Dockerfile and docker-compose with Postgres
- expose environment variables for backend
- fetch product data from API in ecommerce page
- fetch dashboard data from backend via server actions
- update README with setup and deployment info

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684018f9824083338d47bd57ecc60ba9